### PR TITLE
feat: Add .metrics getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ const SinkCustom = class SinkCustom extends Sink {
         });
     }
 
+    get metrics() {
+        return // Custom metric stream code
+    }
+
     get [Symbol.toStringTag]() {
         return 'SinkCustom';
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -17,6 +17,10 @@ const Sink = class Sink {
         throw new Error('.exist method is not implemented');
     }
 
+    get metrics() {
+        throw new Error('.metrics getter is not implemented');
+    }
+
     static validateFilePath(filePath) {
         if (typeof filePath !== 'string') throw new TypeError('Argument must be a String');
         if (filePath === '') throw new TypeError('Argument can not be an empty String');

--- a/test/main.js
+++ b/test/main.js
@@ -44,7 +44,7 @@ test('Sink() - Call .exist() method', (t) => {
 test('Sink() - Call .metrics getter', (t) => {
     const obj = new Sink();
     t.throws(() => {
-        obj.metrics;
+        const metric = obj.metrics; // eslint-disable-line no-unused-vars
     }, /.metrics getter is not implemented/, 'Should throw');
     t.end();
 });

--- a/test/main.js
+++ b/test/main.js
@@ -41,6 +41,14 @@ test('Sink() - Call .exist() method', (t) => {
     t.end();
 });
 
+test('Sink() - Call .metrics getter', (t) => {
+    const obj = new Sink();
+    t.throws(() => {
+        obj.metrics;
+    }, /.metrics getter is not implemented/, 'Should throw');
+    t.end();
+});
+
 test('Sink() - Call .validateFilePath() with legal value', (t) => {
     t.equal(Sink.validateFilePath('foo'), 'foo', 'Should return value');
     t.end();


### PR DESCRIPTION
This ads a `.metrics` getter to the sink interface making it so that Sink implementations have to expose metrics.